### PR TITLE
test[aqa]: CSS Selector specifies 'svg' element one level deep

### DIFF
--- a/test/pageobjects/developer.page.js
+++ b/test/pageobjects/developer.page.js
@@ -30,13 +30,13 @@ class DeveloperPage extends Page {
 
   async browseAllListings() {
     const productsPanel = await this.getProductsPanel();
+
     await (
       await (
         await productsPanel.$('#filter-chips')
-      ).$$('[role="button"]')
+      ).$$('[role="button"] > svg')
     ).forEach(async (chip) => {
-      const btn = await chip.$('svg');
-      return btn.click();
+      return chip.click();
     });
   }
 


### PR DESCRIPTION
A new 'svg' type of element was added in the HTML and was being selected. The element being selected was no longer the "x" button to remove a filter but instead was the new icon indicating certification status. The more specific 'svg element one level deep' once again select the correct element with the "x".